### PR TITLE
Add basic interactive mode

### DIFF
--- a/web/interactive.html
+++ b/web/interactive.html
@@ -1,0 +1,14 @@
+<html>
+<head>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="css/oc.css">
+    <link rel="stylesheet" href="css/navbar.css">
+    <script type="application/javascript" src="scripts/Controllers/Story/InteractiveIndexController.dart.js"></script>
+    <title>Interactive SBURB Session</title>
+</head>
+<body>
+    <div id="navbar"></div>
+    <div id="seedText"></div>
+    <div id="story"></div>
+</body>
+</html>

--- a/web/scripts/Controllers/Interactive/InteractiveSimController.dart
+++ b/web/scripts/Controllers/Interactive/InteractiveSimController.dart
@@ -1,0 +1,29 @@
+import 'dart:async';
+import 'dart:html';
+
+import '../Misc/SimController.dart';
+import '../../SBURBSim.dart';
+
+class InteractiveSimController extends SimController {
+  ButtonElement continueButton;
+  Completer<void> _waiter;
+
+  InteractiveSimController() : super() {
+    continueButton = ButtonElement()
+      ..id = 'continueButton'
+      ..text = 'Continue';
+    continueButton.style.display = 'none';
+    storyElement.append(continueButton);
+    continueButton.onClick.listen((e) {
+      continueButton.style.display = 'none';
+      _waiter?.complete();
+    });
+  }
+
+  @override
+  Future<void> afterTick(Session session) async {
+    _waiter = Completer<void>();
+    continueButton.style.display = 'block';
+    await _waiter.future;
+  }
+}

--- a/web/scripts/Controllers/Misc/SimController.dart
+++ b/web/scripts/Controllers/Misc/SimController.dart
@@ -201,4 +201,8 @@ abstract class SimController {
             statData.resetTurns();
         }
     }
+
+    /// Hook for controllers to run logic after each session tick.
+    /// Default implementation does nothing.
+    Future<void> afterTick(Session session) async {}
 }

--- a/web/scripts/Controllers/Story/InteractiveIndexController.dart
+++ b/web/scripts/Controllers/Story/InteractiveIndexController.dart
@@ -1,0 +1,32 @@
+import '../../SBURBSim.dart';
+import '../../navbar.dart';
+import 'dart:async';
+import 'dart:html';
+import '../Interactive/InteractiveSimController.dart';
+
+Future<void> main() async {
+  await globalInit();
+  loadNavbar();
+
+  window.onError.listen((Event event) {
+    ErrorEvent e = event as ErrorEvent;
+    printCorruptionMessage(SimController.instance.currentSessionForErrors, e);
+    return;
+  });
+
+  new InteractiveSimController();
+
+  if (getParameterByName("seed", null) != null) {
+    SimController.instance.initial_seed = int.parse(getParameterByName("seed", null));
+  } else {
+    SimController.instance.initial_seed = getRandomSeed();
+  }
+
+  SimController.instance.shareableURL();
+  startSession();
+}
+
+Future<void> startSession() async {
+  Session session = new Session(SimController.instance.initial_seed);
+  await session.startSession();
+}

--- a/web/scripts/SessionEngine/session.dart
+++ b/web/scripts/SessionEngine/session.dart
@@ -1356,6 +1356,7 @@ class Session {
         }else if (!this.stats.doomedTimeline) {
             this.timeTillReckoning += -1;
             this.processScenes(this.players);
+            await SimController.instance.afterTick(this);
             SimController.instance.gatherStats(this);
             await window.requestAnimationFrame(tick);
         }


### PR DESCRIPTION
## Summary
- support pausing a session after each tick
- provide InteractiveSimController that waits for user input
- wire up interactive entry point

## Testing
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_687fe2f131348326a41c01d670f0a8a8