### PR TITLE
Add interactive session page

### DIFF
--- a/web/interactive.html
+++ b/web/interactive.html
@@ -1,0 +1,59 @@
+<html>
+
+<head>
+	<!-- Global site tag (gtag.js) - Google Analytics -->
+	<script async src="https://www.googletagmanager.com/gtag/js?id=UA-118163395-1"></script>
+	<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'UA-118163395-1');
+</script>
+	<meta charset="utf-8">
+	<meta name="description" content="Homestuck SBURB Simulator, see how millions of non canon sessions turn out, then bug and fuss and meddle to change things. Similar to a 'Zero Player Game', with a focus on story over gameplay, but has limited user interactivity. Runs in most browsers.">
+
+	<link rel="stylesheet" href="css/oc.css">
+	<link rel="stylesheet" href="css/navbar.css">
+	<script type="text/javascript" src="scripts/includes/lz-string.min.js"></script>
+	<!--<script type="text/javascript" src="scripts/includes/stacktrace.min.js"></script>-->
+	<script type="text/javascript" src="scripts/includes/tracer.js"></script>
+	<script type="application/javascript" src="scripts/Controllers/Story/InteractiveIndexController.dart.js"></script>
+	<!---->
+	<title>
+		SBURB Session Simulator by jadedResearcher
+	</title>
+</head>
+
+<body>
+	<div id="navbar"></div>
+	<h3 id="seedText"><a href = "index2.html">Shareable URL </a></h3>
+	<div id="debug"></div>
+
+	<a href="https://www.patreon.com/bePatron?u=6476827" data-patreon-widget-type="become-patron-button">Become a Patron!</a><script async src="https://c6.patreon.com/becomePatronButton.bundle.js"></script>
+        <button id="startSession">Start Session</button>
+        <button id="stopSession">Stop Session</button>
+	<div id="story">
+
+		<div id="loading_stats"></div>
+		<img id="loading.png" src="images/loading.png"></div>
+
+	<div class="whiteCenterThingy" id='charSheets'>
+		<table><tr><td>
+			<a href ="www.farragofiction.com"><img width="190px" src = "images/ff_logo.png"></a>
+			<Td>
+
+				<iframe src="https://store.steampowered.com/widget/929640/?t=Want%20to%20support%20FarragoFiction%2C%20makers%20of%20SBURBSim%2C%20WigglerSim%2C%20DollSim%20and%20more%3F%20Check%20out%20our%20game%20Farragnarok%20on%20Steam%20and%20see%20if%20you%20can%20decipher%20the%20many%20puzzles%20of%20each%20of%20its%20Lands." frameborder="0" width="800" height="190"></iframe>
+	</td>
+	</tr>
+	</table>
+	</div>
+
+
+
+
+	<div id="image_staging"> </div>
+	<div id="loading_image_staging"> </div>
+</body>
+
+</html>

--- a/web/scripts/Controllers/Story/InteractiveIndexController.dart
+++ b/web/scripts/Controllers/Story/InteractiveIndexController.dart
@@ -1,0 +1,44 @@
+import '../../SBURBSim.dart';
+import '../../navbar.dart';
+import 'dart:async';
+import 'dart:html';
+import 'StoryController.dart';
+
+Session? currentSession;
+
+Future<void> main() async {
+  await globalInit();
+  startTime = new DateTime.now();
+  new Timer(new Duration(milliseconds: 1000), () => window.scrollTo(0, 0));
+
+  window.onError.listen((Event event) {
+    ErrorEvent e = event as ErrorEvent;
+    printCorruptionMessage(SimController.instance.currentSessionForErrors, e);
+    return;
+  });
+
+  loadNavbar();
+  new StoryController();
+
+  if (getParameterByName("seed", null) != null) {
+    SimController.instance.initial_seed = int.parse(getParameterByName("seed", null));
+  } else {
+    SimController.instance.initial_seed = getRandomSeed();
+  }
+
+  SimController.instance.shareableURL();
+
+  ButtonElement? startButton = querySelector('#startSession') as ButtonElement?;
+  ButtonElement? stopButton = querySelector('#stopSession') as ButtonElement?;
+  startButton?.onClick.listen((_) => startSession());
+  stopButton?.onClick.listen((_) => stopSession());
+}
+
+Future<void> startSession() async {
+  currentSession = new Session(SimController.instance.initial_seed);
+  await currentSession!.startSession();
+}
+
+void stopSession() {
+  window.location.reload();
+}


### PR DESCRIPTION
## Summary
- create interactive controller for manual session control
- add interactive HTML page with start/stop buttons

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fcc43cbd8832686a8692bb07be7ce